### PR TITLE
SEO: Show warning when meta title exceeds 55 characters and meta description exceeds 155 characters 

### DIFF
--- a/src/kitconcept/seo/behaviors/seo.py
+++ b/src/kitconcept/seo/behaviors/seo.py
@@ -7,7 +7,6 @@ from zope import schema
 from zope.component import adapter
 from zope.interface import implementer
 from zope.interface import provider
-from plone.autoform import directives
 
 
 @provider(IFormFieldProvider)
@@ -29,39 +28,23 @@ class ISeo(model.Schema):
         ],
     )
 
-    directives.widget(
-        "seo_title",
-        frontendOptions={
-            "widgetProps": {
-                "maxLength": 55,
-            }
-        },
-    )
-
-    directives.widget(
-        "seo_description",
-        frontendOptions={
-            "widgetProps": {
-                "maxLength": 155,
-            }
-        },
-    )
-
     seo_title = schema.TextLine(
         title=_("Title"),
         description=_(
             "Override the meta title. When empty the default title will "
             + "be used. Use maximum 55 characters."
         ),
+        max_length = 55,
         required=False,
     )
 
-    seo_description = schema.Text(
+    seo_description = schema.TextLine(
         title=_("Description"),
         description=_(
             "Override the meta description. When empty the default "
             + "description will be used. Use maximum 155 characters."
         ),
+        max_length = 155,
         required=False,
     )
 


### PR DESCRIPTION
<img width="297" alt="Screenshot 2025-02-25 at 7 29 09 PM" src="https://github.com/user-attachments/assets/cbc20fcc-2b90-40ae-b3db-dcebed1167f2" />
